### PR TITLE
MI-97 adding project configuration on generator step for clients

### DIFF
--- a/tools/openapi-plugin/package.json
+++ b/tools/openapi-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aligent/openapi-plugin",
   "version": "0.0.1",
-  "type": "module",
+  "type": "commonjs",
   "dependencies": {
     "openapi-typescript": "^7.4.1",
     "@nx/devkit": "19.8.3",


### PR DESCRIPTION
This fixes the bug where generated clients would not be present in the nx project graph. 

The code wasn't using `addProjectConfiguration` in its generation step, which is the step responsible for adding the project.json to directory and having Nx automatically pick it up in the tree. 