### PR TITLE
MI-99: Add/remove generated client from tsconfig.base.json paths

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,6 +4,9 @@
         "defaultBase": "origin/staging"
     },
     "generators": {
+        "@aligent/openapi-plugin:client": {
+            "brand": "brand-name"
+        },
         "@aligent/serverless-plugin:service": {
             "brand": "brand-name"
         },

--- a/tools/openapi-plugin/package.json
+++ b/tools/openapi-plugin/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "openapi-typescript": "^7.4.1",
     "@nx/devkit": "19.8.3",
+    "@nx/js": "19.8.3",
     "vitest": "2.0.0",
     "tslib": "^2.6.2",
     "@redocly/openapi-core": "^1.25.5"

--- a/tools/openapi-plugin/package.json
+++ b/tools/openapi-plugin/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "openapi-typescript": "^7.4.1",
     "@nx/devkit": "19.8.3",
-    "@nx/js": "19.8.3",
     "vitest": "2.0.0",
     "tslib": "^2.6.2",
     "@redocly/openapi-core": "^1.25.5"

--- a/tools/openapi-plugin/src/generators/client/generator.ts
+++ b/tools/openapi-plugin/src/generators/client/generator.ts
@@ -4,11 +4,11 @@ import {
     formatFiles,
     generateFiles,
     joinPathFragments,
+    updateJson,
 } from '@nx/devkit';
 import openapiTS, { astToString } from 'openapi-typescript';
 import { loadConfig } from '@redocly/openapi-core';
 import { ClientGeneratorSchema } from './schema';
-import { addTsConfigPath } from '@nx/js';
 
 export async function clientGenerator(
     tree: Tree,
@@ -120,6 +120,41 @@ async function copySchema(
             schemaBuffer
         );
     }
+}
+
+// These utility functions are only exported by @nx/js, not @nx/devkit
+// They're simple so we recreate them here instead of adding @nx/js as a dependency
+// Source: https://github.com/nrwl/nx/blob/master/packages/js/src/utils/typescript/ts-config.ts
+export function getRootTsConfigPathInTree(tree: Tree): string {
+    for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
+        if (tree.exists(path)) {
+            return path;
+        }
+    }
+
+    return 'tsconfig.base.json';
+}
+
+function addTsConfigPath(
+    tree: Tree,
+    importPath: string,
+    lookupPaths: string[]
+) {
+    updateJson(tree, getRootTsConfigPathInTree(tree), (json) => {
+        json.compilerOptions ??= {};
+        const c = json.compilerOptions;
+        c.paths ??= {};
+
+        if (c.paths[importPath]) {
+            throw new Error(
+                `You already have a library using the import path "${importPath}". Make sure to specify a unique one.`
+            );
+        }
+
+        c.paths[importPath] = lookupPaths;
+
+        return json;
+    });
 }
 
 export default clientGenerator;

--- a/tools/openapi-plugin/src/generators/client/generator.ts
+++ b/tools/openapi-plugin/src/generators/client/generator.ts
@@ -14,7 +14,14 @@ export async function clientGenerator(
     tree: Tree,
     options: ClientGeneratorSchema
 ) {
-    const { brand, name, schemaPath, remote, configPath } = options;
+    const {
+        name,
+        schemaPath,
+        remote,
+        configPath,
+        importPath = `@clients/${name}`,
+    } = options;
+
     const projectRoot = `clients/${name}`;
 
     // Parse schema into type definition
@@ -51,7 +58,7 @@ export async function clientGenerator(
     );
 
     // Add the project to the tsconfig paths so it can be imported by namespace
-    addTsConfigPath(tree, `@${brand}/${name}`, [
+    addTsConfigPath(tree, importPath, [
         joinPathFragments(projectRoot, './src', 'index.ts'),
     ]);
 

--- a/tools/openapi-plugin/src/generators/client/generator.ts
+++ b/tools/openapi-plugin/src/generators/client/generator.ts
@@ -1,18 +1,20 @@
 import {
     Tree,
     addProjectConfiguration,
+    formatFiles,
     generateFiles,
     joinPathFragments,
 } from '@nx/devkit';
 import openapiTS, { astToString } from 'openapi-typescript';
 import { loadConfig } from '@redocly/openapi-core';
 import { ClientGeneratorSchema } from './schema';
+import { addTsConfigPath } from '@nx/js';
 
 export async function clientGenerator(
     tree: Tree,
     options: ClientGeneratorSchema
 ) {
-    const { name, schemaPath, remote, configPath } = options;
+    const { brand, name, schemaPath, remote, configPath } = options;
     const projectRoot = `clients/${name}`;
 
     // Parse schema into type definition
@@ -47,6 +49,13 @@ export async function clientGenerator(
         `/clients/${name}`,
         options
     );
+
+    // Add the project to the tsconfig paths so it can be imported by namespace
+    addTsConfigPath(tree, `@${brand}/${name}`, [
+        joinPathFragments(projectRoot, './src', 'index.ts'),
+    ]);
+
+    await formatFiles(tree);
 }
 
 /**

--- a/tools/openapi-plugin/src/generators/client/schema.d.ts
+++ b/tools/openapi-plugin/src/generators/client/schema.d.ts
@@ -1,4 +1,5 @@
 export interface ClientGeneratorSchema {
+    brand: string;
     name: string;
     schemaPath: string;
     remote?: boolean;

--- a/tools/openapi-plugin/src/generators/client/schema.d.ts
+++ b/tools/openapi-plugin/src/generators/client/schema.d.ts
@@ -1,7 +1,7 @@
 export interface ClientGeneratorSchema {
-    brand: string;
     name: string;
     schemaPath: string;
     remote?: boolean;
     configPath?: string;
+    importPath?: string;
 }

--- a/tools/openapi-plugin/src/generators/client/schema.json
+++ b/tools/openapi-plugin/src/generators/client/schema.json
@@ -3,10 +3,6 @@
     "$id": "Client",
     "type": "object",
     "properties": {
-        "brand": {
-            "type": "string",
-            "description": "Brand name (config this in {workspaceRoot}/nx.json)"
-        },
         "name": {
             "type": "string",
             "description": "Name of the api client.",
@@ -32,6 +28,10 @@
         "configPath": {
             "type": "string",
             "description": "path to the redocly config file responsible for auth. For more information: https://openapi-ts.dev/cli#auth."
+        },
+        "importPath": {
+            "type": "string",
+            "description": "The package name used to import the client, like @myorg/my-awesome-client. Defaults to @clients/{name} if not supplied"
         }
     },
     "required": ["name", "schemaPath"]

--- a/tools/openapi-plugin/src/generators/client/schema.json
+++ b/tools/openapi-plugin/src/generators/client/schema.json
@@ -3,6 +3,10 @@
     "$id": "Client",
     "type": "object",
     "properties": {
+        "brand": {
+            "type": "string",
+            "description": "Brand name (config this in {workspaceRoot}/nx.json)"
+        },
         "name": {
             "type": "string",
             "description": "Name of the api client.",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,9 +12,7 @@
         "skipDefaultLibCheck": true,
         "baseUrl": ".",
         "paths": {
-            "@aligent/openapi-plugin": [
-                "tools/openapi-plugin/src/index.ts"
-            ],
+            "@aligent/openapi-plugin": ["tools/openapi-plugin/src/index.ts"],
             "@aligent/serverless-plugin": [
                 "tools/serverless-plugin/src/index.ts"
             ]


### PR DESCRIPTION
This PR handles adding/removing the generated library from the root tsconfig.base.json paths array.

This is required to allow other projects to import from the library via namespaced import syntax.

I've copied the implementation from the `nx/js:lib` generator